### PR TITLE
fix: update default test glob patterns for fs.glob compatibility

### DIFF
--- a/api/apps/backend/adonisrc.ts
+++ b/api/apps/backend/adonisrc.ts
@@ -73,12 +73,12 @@ export default defineConfig({
   tests: {
     suites: [
       {
-        files: ['tests/unit/**/*.spec(.ts|.js)'],
+        files: ['tests/unit/**/*.spec.{ts,js}'],
         name: 'unit',
         timeout: 2000,
       },
       {
-        files: ['tests/functional/**/*.spec(.ts|.js)'],
+        files: ['tests/functional/**/*.spec.{ts,js}'],
         name: 'functional',
         timeout: 30000,
       },

--- a/inertia-react/adonisrc.ts
+++ b/inertia-react/adonisrc.ts
@@ -77,17 +77,17 @@ export default defineConfig({
   tests: {
     suites: [
       {
-        files: ['tests/unit/**/*.spec(.ts|.js)'],
+        files: ['tests/unit/**/*.spec.{ts,js}'],
         name: 'unit',
         timeout: 2000,
       },
       {
-        files: ['tests/functional/**/*.spec(.ts|.js)'],
+        files: ['tests/functional/**/*.spec.{ts,js}'],
         name: 'functional',
         timeout: 30000,
       },
       {
-        files: ['tests/browser/**/*.spec(.ts|.js)'],
+        files: ['tests/browser/**/*.spec.{ts,js}'],
         name: 'browser',
         timeout: 300000,
       },

--- a/inertia-vue/adonisrc.ts
+++ b/inertia-vue/adonisrc.ts
@@ -77,17 +77,17 @@ export default defineConfig({
   tests: {
     suites: [
       {
-        files: ['tests/unit/**/*.spec(.ts|.js)'],
+        files: ['tests/unit/**/*.spec.{ts,js}'],
         name: 'unit',
         timeout: 2000,
       },
       {
-        files: ['tests/functional/**/*.spec(.ts|.js)'],
+        files: ['tests/functional/**/*.spec.{ts,js}'],
         name: 'functional',
         timeout: 30000,
       },
       {
-        files: ['tests/browser/**/*.spec(.ts|.js)'],
+        files: ['tests/browser/**/*.spec.{ts,js}'],
         name: 'browser',
         timeout: 300000,
       },


### PR DESCRIPTION


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
                                                                                                                                                                                            
Japa 5.0.0 replaced `fast-glob` with Node.js's built-in `fs.glob`, which doesn't support fast-glob's extended syntax. The default glob pattern `(.ts|.js)` fails to match test files, causing test suites to discover zero tests.                                                                                                                                                                         
                                                                                                                                                                                                         
### Changes                                                                                                                                                                                            
- Replace `(.ts|.js)` with `.{ts,js}` in test suite file patterns                                                                                                                                      
- Applies to unit, functional, and browser test suites                                                                                                                                                 
- Uses standard glob brace expansion syntax supported by `fs.glob`                                                                                                                                     
                                                                                                                                                                                                        