### PR TITLE
fix: update node engine to >=24.0.0

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -22,7 +22,7 @@
     "turbo": "^2.3.3"
   },
   "engines": {
-    "node": ">=20.6.0"
+    "node": ">=24.0.0"
   },
   "packageManager": "npm@10.9.2",
   "prettier": "@adonisjs/prettier-config"


### PR DESCRIPTION
### 🔗 Linked issue

[#3](https://github.com/adonisjs/starter-kits/issues/3)

### ❓ Type of change

- [ ] 🐞 Bug fix 

### 📚 Description

Changed Node.js engine from `>=20.6.0` to `>=24.0.0` in `api/package.json` to align with project recommendations.
[Resolves #3](https://github.com/adonisjs/starter-kits/issues/3)

