### PR TITLE
fix: do not release secret in encryption config

### DIFF
--- a/api-monorepo/apps/backend/config/encryption.ts
+++ b/api-monorepo/apps/backend/config/encryption.ts
@@ -13,7 +13,7 @@ const encryptionConfig = defineConfig({
        * Keys used for encryption/decryption.
        * First key encrypts, all keys are tried for decryption.
        */
-      keys: [env.get('APP_KEY').release()],
+      keys: [env.get('APP_KEY')],
 
       /**
        * Stable identifier for this driver.

--- a/api/config/encryption.ts
+++ b/api/config/encryption.ts
@@ -13,7 +13,7 @@ const encryptionConfig = defineConfig({
        * Keys used for encryption/decryption.
        * First key encrypts, all keys are tried for decryption.
        */
-      keys: [env.get('APP_KEY').release()],
+      keys: [env.get('APP_KEY')],
 
       /**
        * Stable identifier for this driver.

--- a/inertia-react/config/encryption.ts
+++ b/inertia-react/config/encryption.ts
@@ -13,7 +13,7 @@ const encryptionConfig = defineConfig({
        * Keys used for encryption/decryption.
        * First key encrypts, all keys are tried for decryption.
        */
-      keys: [env.get('APP_KEY').release()],
+      keys: [env.get('APP_KEY')],
 
       /**
        * Stable identifier for this driver.

--- a/inertia-vue/config/encryption.ts
+++ b/inertia-vue/config/encryption.ts
@@ -13,7 +13,7 @@ const encryptionConfig = defineConfig({
        * Keys used for encryption/decryption.
        * First key encrypts, all keys are tried for decryption.
        */
-      keys: [env.get('APP_KEY').release()],
+      keys: [env.get('APP_KEY')],
 
       /**
        * Stable identifier for this driver.


### PR DESCRIPTION
Keys array is allowed to contain instances of `Secret`.

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
