### PR TITLE
fix(pnpm): approve build scripts required by pnpm v11 install

### DIFF
--- a/api-monorepo/pnpm-workspace.yaml
+++ b/api-monorepo/pnpm-workspace.yaml
@@ -1,5 +1,9 @@
 packages:
   - 'apps/*'
 
+allowBuilds:
+  '@swc/core': true
+  better-sqlite3: true
+  esbuild: true
 onlyBuiltDependencies:
   - better-sqlite3

--- a/hypermedia/pnpm-workspace.yaml
+++ b/hypermedia/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
+allowBuilds:
+  '@swc/core': true
+  better-sqlite3: true
+  esbuild: true
 onlyBuiltDependencies:
   - better-sqlite3

--- a/inertia-react/pnpm-workspace.yaml
+++ b/inertia-react/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
+allowBuilds:
+  '@swc/core': true
+  better-sqlite3: true
+  esbuild: true
 onlyBuiltDependencies:
   - better-sqlite3

--- a/inertia-vue/pnpm-workspace.yaml
+++ b/inertia-vue/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
+allowBuilds:
+  '@swc/core': true
+  better-sqlite3: true
+  esbuild: true
 onlyBuiltDependencies:
   - better-sqlite3


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In Pnpm v11, build scripts must be approved and `onlyBuiltDependencies` has been replaced by `allowBuilds`. So, `pnpm create` fails with an exit code 1 during the dependencies install step.
https://pnpm.io/blog/releases/11.0

This PR allows the required builds in pnpm-workspace.yaml.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
