### PR TITLE
chore: update tuyau documentation link in readmes

### DIFF
--- a/api-monorepo/apps/backend/README.md
+++ b/api-monorepo/apps/backend/README.md
@@ -70,7 +70,7 @@ This backend workspace is designed to help you build production-ready APIs with 
   <tr>
     <td><strong>Type Safety</strong></td>
     <td>
-      <a href="https://tuyau.dev">Tuyau</a> - End-to-end type safety for API calls
+      <a href="https://docs.adonisjs.com/guides/frontend/api-client">Tuyau</a> - End-to-end type safety for API calls
     </td>
   </tr>
   <tr>
@@ -162,7 +162,7 @@ Your API will be running at `http://localhost:3333`
       <span>Complete guide to AdonisJS</span>
     </td>
     <td>
-      <a href="https://tuyau.dev"><strong>🔒 Tuyau</strong></a>
+      <a href="https://docs.adonisjs.com/guides/frontend/api-client"><strong>🔒 Tuyau</strong></a>
       <br>
       <span>Type-safe API calls</span>
     </td>

--- a/api-monorepo/apps/frontend/README.md
+++ b/api-monorepo/apps/frontend/README.md
@@ -361,7 +361,7 @@ NUXT_PUBLIC_API_URL=http://localhost:3333
 
 ## 📖 Learn More
 
-- [Tuyau Documentation](https://tuyau.dev) - Type-safe API clients
+- [Tuyau Documentation](https://docs.adonisjs.com/guides/frontend/api-client) - Type-safe API clients
 - [TanStack Start Documentation](https://tanstack.com/start) - TanStack Start framework
 - [Nuxt Documentation](https://nuxt.com) - Nuxt framework
 - [AdonisJS Documentation](https://docs.adonisjs.com) - Backend framework

--- a/api/README.md
+++ b/api/README.md
@@ -69,7 +69,7 @@ This starter kit is designed to help you build production-ready APIs with Adonis
   <tr>
     <td><strong>Type Safety</strong></td>
     <td>
-      <a href="https://tuyau.dev">Tuyau</a> - End-to-end type safety for API calls
+      <a href="https://docs.adonisjs.com/guides/frontend/api-client">Tuyau</a> - End-to-end type safety for API calls
     </td>
   </tr>
   <tr>
@@ -149,7 +149,7 @@ Your API will be running at `http://localhost:3333`
       <span>Complete guide to AdonisJS</span>
     </td>
     <td>
-      <a href="https://tuyau.dev"><strong>🔒 Tuyau</strong></a>
+      <a href="https://docs.adonisjs.com/guides/frontend/api-client"><strong>🔒 Tuyau</strong></a>
       <br>
       <span>Type-safe API calls</span>
     </td>

--- a/inertia-react/README.md
+++ b/inertia-react/README.md
@@ -97,7 +97,7 @@ This starter kit is designed to help you build production-ready single-page appl
   <tr>
     <td><strong>Type Safety</strong></td>
     <td>
-      <a href="https://tuyau.dev">Tuyau</a> - End-to-end type safety for routes and API calls
+      <a href="https://docs.adonisjs.com/guides/frontend/api-client">Tuyau</a> - End-to-end type safety for routes and API calls
     </td>
   </tr>
   <tr>
@@ -194,7 +194,7 @@ Your app will be running at `http://localhost:3333`
       <span>Modern React with hooks</span>
     </td>
     <td>
-      <a href="https://tuyau.dev"><strong>🔒 Tuyau</strong></a>
+      <a href="https://docs.adonisjs.com/guides/frontend/api-client"><strong>🔒 Tuyau</strong></a>
       <br>
       <span>Type-safe routing and API calls</span>
     </td>

--- a/inertia-vue/README.md
+++ b/inertia-vue/README.md
@@ -97,7 +97,7 @@ This starter kit is designed to help you build production-ready single-page appl
   <tr>
     <td><strong>Type Safety</strong></td>
     <td>
-      <a href="https://tuyau.dev">Tuyau</a> - End-to-end type safety for routes and API calls
+      <a href="https://docs.adonisjs.com/guides/frontend/api-client">Tuyau</a> - End-to-end type safety for routes and API calls
     </td>
   </tr>
   <tr>
@@ -194,7 +194,7 @@ Your app will be running at `http://localhost:3333`
       <span>Modern Vue with Composition API</span>
     </td>
     <td>
-      <a href="https://tuyau.dev"><strong>🔒 Tuyau</strong></a>
+      <a href="https://docs.adonisjs.com/guides/frontend/api-client"><strong>🔒 Tuyau</strong></a>
       <br>
       <span>Type-safe routing and API calls</span>
     </td>


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Simple update to the links to the Tuyau documentation in the README.md files, which is now included directly in the AdonisJS documentation. tuyau.dev does not seem to exist anymore.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
